### PR TITLE
feat!: putting the replied message widget builder inside the reply message widget

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ doc/api/
 .flutter-plugins
 /.flutter-plugins-dependencies
 chat_ui.iml
+
+# for those developers who use fvm not to upload the whole sdk
+.fvm/

--- a/lib/src/models/replied_message_configuration.dart
+++ b/lib/src/models/replied_message_configuration.dart
@@ -75,6 +75,10 @@ class RepliedMessageConfiguration {
   /// Color for microphone icon.
   final Color? micIconColor;
 
+  /// Customize what happens when user tap a reply message.
+  /// The default behaviour is to scroll to the message if [repliedMsgAutoScrollConfig] is enabled
+  final ReplyMessageCallBack? onReplyTapped;
+
   const RepliedMessageConfiguration({
     this.verticalBarColor,
     this.backgroundColor,
@@ -92,5 +96,6 @@ class RepliedMessageConfiguration {
     this.opacity,
     this.repliedMsgAutoScrollConfig = const RepliedMsgAutoScrollConfig(),
     this.micIconColor,
+    this.onReplyTapped,
   });
 }

--- a/lib/src/widgets/chat_bubble_widget.dart
+++ b/lib/src/widgets/chat_bubble_widget.dart
@@ -309,15 +309,12 @@ class _ChatBubbleWidgetState extends State<ChatBubbleWidget> {
             ),
           ),
         if (replyMessage.isNotEmpty)
-          widget.repliedMessageConfig?.repliedMessageWidgetBuilder != null
-              ? widget.repliedMessageConfig!
-                  .repliedMessageWidgetBuilder!(widget.message.replyMessage)
-              : ReplyMessageWidget(
-                  message: widget.message,
-                  repliedMessageConfig: widget.repliedMessageConfig,
-                  onTap: () => widget.onReplyTap
-                      ?.call(widget.message.replyMessage.messageId),
-                ),
+          ReplyMessageWidget(
+            message: widget.message,
+            repliedMessageConfig: widget.repliedMessageConfig,
+            onTap: () =>
+                widget.onReplyTap?.call(widget.message.replyMessage.messageId),
+          ),
         MessageView(
           outgoingChatBubbleConfig:
               widget.chatBubbleConfig?.outgoingChatBubbleConfig,

--- a/lib/src/widgets/reply_message_widget.dart
+++ b/lib/src/widgets/reply_message_widget.dart
@@ -50,6 +50,19 @@ class ReplyMessageWidget extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    if (repliedMessageConfig?.repliedMessageWidgetBuilder != null) {
+      return GestureDetector(
+        onTap: () {
+          if (repliedMessageConfig!.onReplyTapped != null) {
+            repliedMessageConfig!.onReplyTapped!.call(message.replyMessage);
+          }
+          onTap?.call();
+        },
+        child: repliedMessageConfig!
+            .repliedMessageWidgetBuilder!(message.replyMessage),
+      );
+    }
+
     final currentUser = ChatViewInheritedWidget.of(context)?.currentUser;
     final replyBySender = message.replyMessage.replyBy == currentUser?.id;
     final textTheme = Theme.of(context).textTheme;
@@ -59,7 +72,12 @@ class ReplyMessageWidget extends StatelessWidget {
         chatController?.getUserFromId(message.replyMessage.replyBy);
     final replyBy = replyBySender ? PackageStrings.you : messagedUser?.name;
     return GestureDetector(
-      onTap: onTap,
+      onTap: () {
+        if (repliedMessageConfig!.onReplyTapped != null) {
+          repliedMessageConfig!.onReplyTapped!.call(message.replyMessage);
+        }
+        onTap?.call();
+      },
       child: Container(
         margin: repliedMessageConfig?.margin ??
             const EdgeInsets.only(


### PR DESCRIPTION


# Description

I put the `repliedMessageWidgetBuilder` inside the `ReplyMessageWidget`.

This allows to keep the scroll action when tapping the reply message.

Also I modified the `RepliedMessageConfiguration` to add a callback for those who what to modify the behaviour of the tap gesture


## Checklist
<!--
Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes with `[x]`. If some checkbox is not applicable, mark it as `[ ]`.
-->

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have followed the [Contributor Guide] when preparing my PR.
- [ ] I have updated/added tests for ALL new/updated/fixed functionality.
- [ ] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [ ] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?
### Migration instructions

- [X] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.

If any developer was implementing `RepliedMessageConfiguration.repliedMessageWidgetBuilder` they should know it's now behing the `ReplyMessageWidget` and not outside, soy they should provide the `RepliedMessageConfiguration.onReplyTapped` parameter to control the tap action on the replied message.

If you want to scroll to the replied message then you don't need to do anything.
