### PR TITLE
fix: 🐛 Unfocus text field before picking/capturing an image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## [2.4.2] (unreleased)
 
+* **Fix**: [266](https://github.com/SimformSolutionsPvtLtd/flutter_chatview/issues/266)
+  Fix the keyboard overlapping the text field
 * **Feat**: [296](https://github.com/SimformSolutionsPvtLtd/flutter_chatview/issues/296)
   Added support of internationalization for strings that are used in chat view
 * **Fix**: [303](https://github.com/SimformSolutionsPvtLtd/flutter_chatview/issues/303)

--- a/lib/src/widgets/chatui_textfield.dart
+++ b/lib/src/widgets/chatui_textfield.dart
@@ -405,7 +405,9 @@ class _ChatUITextFieldState extends State<ChatUITextField> {
     ImageSource imageSource, {
     ImagePickerConfiguration? config,
   }) async {
+    final hasFocus = widget.focusNode.hasFocus;
     try {
+      widget.focusNode.unfocus();
       final XFile? image = await _imagePicker.pickImage(
         source: imageSource,
         maxHeight: config?.maxHeight,
@@ -422,6 +424,18 @@ class _ChatUITextFieldState extends State<ChatUITextField> {
       widget.onImageSelected(imagePath ?? '', '');
     } catch (e) {
       widget.onImageSelected('', e.toString());
+    } finally {
+      // To maintain the iOS native behavior of text field,
+      // When the user taps on the gallery icon, and the text field has focus,
+      // the keyboard should close.
+      // We need to request focus again to open the keyboard.
+      // This is not required for Android.
+      // This is a workaround for the issue where the keyboard remain open and overlaps the text field.
+
+      // https://github.com/SimformSolutionsPvtLtd/chatview/issues/266
+      if (imageSource == ImageSource.gallery && Platform.isIOS && hasFocus) {
+        widget.focusNode.requestFocus();
+      }
     }
   }
 


### PR DESCRIPTION
# Description


https://github.com/user-attachments/assets/35529651-a165-4312-8867-95ff32e193d9



<!--
Provide a description of what this PR is doing.
If you're modifying existing behavior, describe the existing behavior, how this PR is changing it,
and what motivated the change. If this is a breaking change, specify explicitly which APIs were
changed.
-->


## Checklist
<!--
Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes with `[x]`. If some checkbox is not applicable, mark it as `[ ]`.
-->

- [X] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [X] I have followed the [Contributor Guide] when preparing my PR.
- [ ] I have updated/added tests for ALL new/updated/fixed functionality.
- [X] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [X] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?
<!--
Would your PR require ChatView users to update their apps following your change?
If yes, then the title of the PR should include "!" (for example, `feat!:`, `fix!:`). See
[Conventional Commit] for details. Also, for a breaking PR uncomment and fill in the "Migration
instructions" section below.
### Migration instructions
If the PR is breaking, uncomment this header and add instructions for how to migrate from the
currently released version to the new proposed way.
-->

- [ ] Yes, this PR is a breaking change.
- [X] No, this PR is not a breaking change.


## Related Issues
<!--
Indicate which issues this PR resolves, if any. For example:
Closes #1234
!-->
Closes #266 

<!-- Links -->
[Contributor Guide]: https://github.com/SimformSolutionsPvtLtd/chatview/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org